### PR TITLE
Use predicate in all nullable methods

### DIFF
--- a/src/Nullable.php
+++ b/src/Nullable.php
@@ -44,7 +44,9 @@ class Nullable
 
     public function getOrAbort($code, $message = '', array $headers = [])
     {
-        if (! is_null($this->result)) {
+        $p = $this->getPredicate();
+
+        if (! $p($this->result)) {
             return $this->result;
         }
 
@@ -53,7 +55,9 @@ class Nullable
 
     public function getOrSend($callable)
     {
-        if (! is_null($this->result)) {
+        $p = $this->getPredicate();
+
+        if (! $p($this->result)) {
             return $this->result;
         }
 
@@ -74,7 +78,9 @@ class Nullable
 
     public function getOrThrow($exception, ...$parameters)
     {
-        if (! is_null($this->result)) {
+        $p = $this->getPredicate();
+
+        if (! $p($this->result)) {
             return $this->result;
         }
 
@@ -83,7 +89,9 @@ class Nullable
 
     public function onValue(callable $callable)
     {
-        if (! is_null($this->result)) {
+        $p = $this->getPredicate();
+
+        if (! $p($this->result)) {
             return call_user_func_array($callable, [$this->result]);
         }
     }

--- a/tests/BasicTest.php
+++ b/tests/BasicTest.php
@@ -14,8 +14,6 @@ class BasicTest extends TestCase
         $this->assertEquals('hello', $value);
 
         $value = nullable(null, ['fgbfgb'], function ($v) {
-            $this->assertNull(null);
-
             return is_null($v);
         })->getOr('hello');
         $this->assertEquals('hello', $value);
@@ -148,6 +146,50 @@ class BasicTest extends TestCase
     {
         $foo = 'foo';
         $value = nullable(null)->onValue(function () use (&$foo) {
+            $foo = $foo.' hello';
+        });
+
+        $this->assertNull($value);
+        $this->assertEquals('foo', $foo);
+    }
+
+    public function testGetOrAbortUsingPredicate()
+    {
+        $this->expectException(NotFoundHttpException::class);
+
+        $value = nullable(null, ['abc'], function ($v) {
+            return is_null($v);
+        })->getOrAbort(404);
+    }
+
+    public function testGetOrSendUsingPredicate()
+    {
+        $this->expectException(HttpResponseException::class);
+
+        $value = nullable(null, ['abc'], function ($v) {
+            return is_null($v);
+        })->getOrSend(function () {
+            return redirect()->to('/');
+        });
+    }
+
+    public function testGetOrThrowUsingPredicate()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('hi');
+        $this->expectExceptionCode(11);
+
+        $value = nullable(null, ['abc'], function ($v) {
+            return is_null($v);
+        })->getOrThrow(InvalidArgumentException::class, 'hi', 11);
+    }
+
+    public function testOnValueUsingPredicate()
+    {
+        $foo = 'foo';
+        $value = nullable(null, ['abc'], function ($v) {
+            return is_null($v);
+        })->onValue(function () use (&$foo) {
             $foo = $foo.' hello';
         });
 


### PR DESCRIPTION
This adds the functionality to use the predicate in nullable object with these methods:
 - getOrAbort
 - getOrSend
 - getOrThrow
 - onValue