### PR TITLE
Fix incorrect type hint in docblocks for getOr and getOrSend methods

### DIFF
--- a/src/Nullable.php
+++ b/src/Nullable.php
@@ -32,7 +32,7 @@ class Nullable
     /**
      * Get the value of nullable object or the default in case of null.
      *
-     * @param  string  $default
+     * @param  string|array  $default
      * @return mixed|null
      */
     public function getOr($default)
@@ -72,7 +72,7 @@ class Nullable
     /**
      * check valid http response.
      *
-     * @param  string  $callable
+     * @param  string|array  $callable
      * @return mixed|null
      */
     public function getOrSend($callable)


### PR DESCRIPTION
This pull request updates the docblocks of the `getOr` and `getOrSend` methods to reflect the correct type hinting.

✔ Changes:

I updated the `@param` annotation for $default and $callable to include an array in addition to a string.

This ensures that the documentation aligns with the expected parameter types, improving code clarity and maintainability.

This change helps IDEs suggest code better by providing more accurate type hints.

No functional changes were made to the code. this is a documentation fix only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded input support for key configurations, allowing both string and array values. This improvement provides greater flexibility when setting default values and handling operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->