### PR TITLE
Add GitHub Action for multi-version testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,84 @@
+name: tests
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3]
+        laravel: [6.*, 7.*, 8.*, 9.*, 10.*]
+        stability: [prefer-lowest, prefer-stable]
+        exclude:
+          - php: 7.2
+            laravel: 8.*
+          - php: 7.2
+            laravel: 9.*
+          - php: 7.2
+            laravel: 10.*
+
+          - php: 7.3
+            laravel: 9.*
+          - php: 7.3
+            laravel: 10.*
+
+          - php: 7.4
+            laravel: 9.*
+          - php: 7.4
+            laravel: 10.*
+
+          - php: 8.0
+            laravel: 6.*
+          - php: 8.0
+            laravel: 10.*
+
+          - php: 8.1
+            laravel: 6.*
+          - php: 8.1
+            laravel: 8.*
+          - php: 8.1
+            laravel: 7.*
+
+          - php: 8.2
+            laravel: 6.*
+          - php: 8.2
+            laravel: 7.*
+          - php: 8.2
+            laravel: 8.*
+
+          - php: 8.3
+            laravel: 6.*
+          - php: 8.3
+            laravel: 7.*
+          - php: 8.3
+            laravel: 8.*
+
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.stability }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, mbstring, bcmath, gd, pdo, zip
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+
+      - name: List Installed Dependencies
+        run: composer show -D
+
+      - name: Execute tests
+        run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
         }
     ],
     "require": {
-        "php": "^7.1.3|7.2.*|7.3.*|7.4.*|8.*",
-        "laravel/framework":"~5.1|6.*|7.*|8.*|9.*|10.*|11.*|12.*"
+        "php": "7.2.*|7.3.*|7.4.*|8.*",
+        "laravel/framework":"6.*|7.*|8.*|9.*|10.*|11.*|12.*"
     },
     "require-dev": {
-        "orchestra/testbench": "~4.0",
+        "orchestra/testbench": ">=4.0",
         "mockery/mockery": "^1.0"
     },
     "autoload": {
@@ -35,10 +35,10 @@
         "imanghafoori/laravel-widgetize": "Gives you a better structure and caching opportunity for your web pages.",
         "imanghafoori/laravel-decorator": "Allows you to easily apply the decorator pattern in a laravel app.",
         "imanghafoori/laravel-anypass": " Allows you login with any password in local environment.",
-	"imanghafoori/laravel-masterpass": "You can easily set a master password without code change.",
+	    "imanghafoori/laravel-masterpass": "You can easily set a master password without code change.",
         "imanghafoori/laravel-terminator": "Gives you opportunity to refactor your controllers."
     },
     "scripts": {
-        "test": "phpunit"
+        "test": "vendor/bin/phpunit"
     }
 }

--- a/phpunit.bat
+++ b/phpunit.bat
@@ -1,4 +1,0 @@
-@ECHO OFF
-setlocal DISABLEDELAYEDEXPANSION
-SET BIN_TARGET=%~dp0/vendor/phpunit/phpunit/phpunit
-php "%BIN_TARGET%" %*

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,7 @@
     <testsuites>
         <testsuite name="Package Test Suite">
             <directory suffix=".php">./tests/</directory>
+            <exclude>./tests/TestCase.php</exclude>
         </testsuite>
     </testsuites>
 
@@ -34,6 +35,6 @@
         </whitelist>
 
 
-      
+
     </filter>
 </phpunit>


### PR DESCRIPTION
- Updated PHP & Laravel support: Removed PHP 7.1 and Laravel 5.x, updated dev dependencies.
- Fixed test script: "test": "vendor/bin/phpunit" to ensure correct binary.
- Removed phpunit.bat: Windows-only file not needed.
- Excluded abstract TestCase: Added <exclude>./tests/TestCase.php</exclude> in phpunit.xml.dist.
- Added GitHub Action: Runs tests on push/PR for CI.

## Summary by Sourcery

Update supported PHP and Laravel versions, streamline test setup, remove obsolete files, and introduce a GitHub Actions CI workflow with matrix testing.

Bug Fixes:
- Fix test script to use vendor/bin/phpunit for correct binary invocation

Enhancements:
- Drop support for PHP 7.1 and Laravel 5.x while relaxing the orchestra/testbench version constraint

CI:
- Add GitHub Actions workflow to run tests on push and pull requests across multiple PHP and Laravel version combinations

Chores:
- Remove the Windows-specific phpunit.bat file